### PR TITLE
rename enums

### DIFF
--- a/src/RuntimeConfig.cpp
+++ b/src/RuntimeConfig.cpp
@@ -47,7 +47,7 @@ void RuntimeConfig::addOutputFileConfig ( std::string file_name, bool packet_buf
 
 void RuntimeConfig::addOutputSockConfig ( std::string sock_addr, uint16_t sock_port, bool use_ipv6, bool use_udp )
 {
-  output_type = OutputType::SOCKET;
+  output_type = OutputType::OSOCKET;
   output_config = new OutputSocketConfig ( sock_addr, sock_port, use_ipv6, use_udp );
 }
 

--- a/src/RuntimeConfig.h
+++ b/src/RuntimeConfig.h
@@ -19,7 +19,7 @@ enum class InputType
 };
 enum class OutputType
 {
-  UNDEFINED, OSTREAM, LIBPCAP_DUMP, SOCKET, LIBPCAP_INJECT //, RAW_SOCKETS
+  UNDEFINED, OSTREAM, LIBPCAP_DUMP, OSOCKET, LIBPCAP_INJECT //, RAW_SOCKETS
 };
 
 struct default_values

--- a/src/RuntimeFactory.cpp
+++ b/src/RuntimeFactory.cpp
@@ -46,7 +46,7 @@ OutputSource* RuntimeFactory::createOutputSource()
     case OutputType::OSTREAM:
       return new OstreamOutput();
       
-    case OutputType::SOCKET:
+    case OutputType::OSOCKET:
       return new SocketOutput();
       
     default:


### PR DESCRIPTION
pktanon fails to build on newer compilers (here: GCC 9.1.0):
```
g++ -DPACKAGE_NAME=\"pktanon\" -DPACKAGE_TARNAME=\"pktanon\" -DPACKAGE_VERSION=\"2.0-beta\" -DPACKAGE_STRING=\"pktanon\ 2.0-beta\" -DPACKAGE_BUGREPORT=\"bless@kit.edu\" -DPACKAGE_URL=\"\" -DPACKAGE=\"pktanon\" -DVERSION=\"2.0-beta\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_STDDEF_H=1 -DHAVE_CXX11=1 -DHAVE_SOCKET=1 -DHAVE_SYS_SOCKET_H=1 -DHAVE_ARPA_INET_H=1 -DHAVE_SYS_IOCTL_H=1 -DHAVE_NETINET_IN_H=1 -DHAVE_LINUX_IF_ETHER_H=1 -DHAVE_NETPACKET_PACKET_H=1 -DHAVE_NET_IF_H=1 -DHAVE_SYS_IOCTL_H=1 -DHAVE_FCNTL_H=1 -DHAVE_PCAP_PCAP_H=1 -I.  -O2 -pipe -Werror=return-type -I../include -g -DTRACE_ENABLED -DHAVE_LIBPCAP -I../libpktanon -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -fdebug-prefix-map=/build/pktanon-2~git20160407.0.2bde4f2+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -c -o OstreamOutput.o OstreamOutput.cpp
In file included from /usr/include/pcap.h:43,
                 from LibpcapRecordsHandler.h:12,
                 from RuntimeFactory.cpp:16:
RuntimeFactory.cpp: In static member function 'static pktanon::OutputSource* pktanon::RuntimeFactory::createOutputSource()':
RuntimeFactory.cpp:49:22: error: expected unqualified-id before 'int'
     case OutputType::SOCKET:
                      ^~~~~~
RuntimeFactory.cpp:49:20: error: expected ':' before 'int'
     case OutputType::SOCKET:
                    ^
                    :
RuntimeFactory.cpp:49:28: error: expected unqualified-id before ':' token
     case OutputType::SOCKET:
                            ^
make[2]: *** [Makefile:446: RuntimeFactory.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/build/pktanon-2~git20160407.0.2bde4f2+dfsg/src'
make[1]: *** [Makefile:487: all-recursive] Error 1
make[1]: Leaving directory '/build/pktanon-2~git20160407.0.2bde4f2+dfsg'
```
Apparently something else now `#define`s (or in some other way influences the value of) `SOCKET` so using that as an enum identifier leads to this problem. Renaming the value has solved the build issue for me.