### PR TITLE
Move #include <pcap.h> outside namespace

### DIFF
--- a/src/Utils.h
+++ b/src/Utils.h
@@ -13,6 +13,11 @@
 #include <PktAnon.h>
 // #include <transformations/ErrorCodes.h>
 
+# ifdef HAVE_LIBPCAP
+
+# include <pcap.h>
+# endif
+
 namespace pktanon
 {
 
@@ -34,8 +39,6 @@ inline void transform_packet ( PCAP_REC_HEADER& record_header, const uint8_t* or
 }
 
 # ifdef HAVE_LIBPCAP
-
-# include <pcap.h>
 
 inline void transform_packet ( struct pcap_pkthdr* pkt_header, const uint8_t* original_packet, uint8_t* transformed_packet, Stats& stats )
 {


### PR DESCRIPTION
Utils.h includes pcap.h from within the pktanon namespace, this causes system structures to be incorrectly placed in the pktanon namespace breaking stuff later. This patch moves the include outside of the namespace.

Thanks to Peter Michael Green for the patch (see #2).
Closes #2.