### PR TITLE
Fix typo in build commands and add the list of required libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,15 @@ can also be easily extended with new anonymization primitives and new packets.
         cd pktanon
         ./bootstrap
         ./configure
-        ./make
+        make
 
-3. PktAnon executable will be pktanon file in the project directory
+3. PktAnon executable will be `pktanon` file in the project directory
+
+### Build requirements
+
+In Debian-based distribution, you can install the build dependencies using this command:
+
+        apt-get install build-essential autoconf libxerces-c-dev nettle-dev libpcap-dev libboost-dev
 
 ## Documentation
 


### PR DESCRIPTION
There is a typo in the README: `make` is indicated as `./make`. I also added the command to install the dependencies on Debian-based distributions.